### PR TITLE
use the correct prop name for value selection

### DIFF
--- a/src/ColorModeSwitcher.js
+++ b/src/ColorModeSwitcher.js
@@ -63,7 +63,7 @@ function ColorModeSwitcher() {
                                         key={scheme.value}
                                         href="#"
                                         selected={scheme.value === colorScheme}
-                                        onClick={() => setScheme(scheme.value)}
+                                        onSelect={() => setScheme(scheme.value)}
                                     >
                                         {scheme.name}
                                     </ActionList.Item>


### PR DESCRIPTION
Hi @maximedegreve 👋🏼  thank you so much for setting this repo up! I used it to build a prototype as an onboarding task 🙂 I just realised that the theme selection menu overlay doesn't get closed when you select a theme. I think it is because the prop name is [onSelect](https://github.com/primer/react/blob/main/src/ActionList/Item.tsx#L53). I changed it and seems to be working fine now. Let me know what you think. Again, thank you so much for the repo 😊 

Before

https://user-images.githubusercontent.com/1446503/184259909-7cf31175-ba47-4b70-a95d-0e670a15d887.mov

After

https://user-images.githubusercontent.com/1446503/184260274-8cb6c31c-c4e4-4ca1-b446-4a35c7172fd0.mov


