### PR TITLE
Remove typescript as we don't use it for this repo yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "react-dom": "^18.2.0",
         "react-is": "^18.2.0",
         "styled-components": "^5.3.8",
-        "typescript": "^4.9",
         "web-vitals": "^3.4.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9369,11 +9369,6 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.9:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"


### PR DESCRIPTION
I don't know why we have `typescript` in the packages because we don't have it configured in this repo yet. It would be great to configure as soon as possible but I don't think there is any benefit to keep the package itself when we don't use it. 