### PR TITLE
Add primer/react-reviewers as CODEOWNERS of repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes should be reviewed by a member of the @react-reviewers team
+* @primer/react-reviewers


### PR DESCRIPTION
In order to keep this template up-to-date with dependencies and contributions, it would be ideal to auto-assign a reviewer group to any open PRs. This is particularly important because this template repo is used in the [React training program offered internally at GitHub](https://thehub.github.com/epd/engineering/learning-and-development/tech-training/react/) (GitHub staff only), so we need to ensure it remains in working order. 

As such, this PR adds @primer/react-reviewers as CODEOWNERS of this repo to help automate review needs.