### PR TITLE
Update devcontainer node VARIANT to 16

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         // Update 'VARIANT' to pick a Node version: 12, 14, 16
-        "args": { "VARIANT": "14" }
+        "args": { "VARIANT": "16" }
     },
 
     // Set *default* container specific settings.json values on container create.


### PR DESCRIPTION
Running `yarn install` in a dev container right now throws:

Via `postCreateCommand`:
![image](https://github.com/primer/react-template/assets/2650445/80518beb-7cbe-4e11-bd72-140b65521942)

On its own:
![image](https://github.com/primer/react-template/assets/2650445/7ff49790-8500-4721-a988-b2c01fc44bb1)

This PR updates devcontainer.json to specify VARIANT 16 instead of 14.