### PR TITLE
Catch up to breaking changes in dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         // Update 'VARIANT' to pick a Node version: 12, 14, 16
-        "args": { "VARIANT": "14" }
+        "args": { "VARIANT": "16" }
     },
 
     // Set *default* container specific settings.json values on container create.

--- a/src/Playground.js
+++ b/src/Playground.js
@@ -1,4 +1,4 @@
-import { Box, Text, Link, StyledOcticon } from '@primer/react'
+import { Box, Text, Link, Octicon } from '@primer/react'
 import {
     MarkGithubIcon,
     CheckIcon,
@@ -66,11 +66,7 @@ function CodeLine({ icon, iconColor, children }) {
     return (
         <Box sx={{ display: 'flex', color: 'fg.onEmphasis', mb: 2 }}>
             <Box sx={{ display: 'flex', mt: '2px', width: 20, minWidth: 20 }}>
-                <StyledOcticon
-                    icon={icon}
-                    size={16}
-                    sx={{ color: iconColor }}
-                />
+                <Octicon icon={icon} size={16} sx={{ color: iconColor }} />
             </Box>
             <Text
                 as="p"
@@ -86,7 +82,7 @@ function Footer() {
     return (
         <Box sx={{ textAlign: 'center' }}>
             <Box sx={{ mr: 2, display: 'inline-block' }}>
-                <StyledOcticon
+                <Octicon
                     icon={MortarBoardIcon}
                     size={16}
                     sx={{ mr: 1, color: 'attention.fg' }}


### PR DESCRIPTION
Fix two problems that I encountered in a new codespace. Both appear to have been caused by dependency changes.

**1. Running `yarn install` in a new codespace right now throws**

Via `postCreateCommand`:
![image](https://github.com/primer/react-template/assets/2650445/80518beb-7cbe-4e11-bd72-140b65521942)

On its own:
![image](https://github.com/primer/react-template/assets/2650445/7ff49790-8500-4721-a988-b2c01fc44bb1)

**Fix:** Update devcontainer.json to specify node 16 instead of 14.

Confirmed a new codespace gets node 16:

![image](https://github.com/primer/react-template/assets/2650445/b2c18557-0597-4a55-832e-1dbf6a4027a8)

-----

**2. Running `yarn start` throws errors like `export 'StyledOcticon' (imported as 'StyledOcticon') was not found in '@primer/react'`**

![image](https://github.com/primer/react-template/assets/2650445/5bb09bb3-a026-4759-9e71-61f01203d0c8)

This broke because `StyledOcticon` was renamed to `Octicon` [in primer/react v35.26.0](https://github.com/primer/react/releases/tag/v35.26.0).

**Fix:** Updated instances of `StyledOcticon` to `Octicon`.

Confirmed a new codespace can build successfully:

![image](https://github.com/primer/react-template/assets/2650445/81e07e52-bc33-4dd6-b7be-87c80668962c)

Confirmed default "Mona's playground" UI works:

![image](https://github.com/primer/react-template/assets/2650445/b3d30c47-c2fd-4c6a-9dc7-d5cd563489e2)
