### PR TITLE
ColorModeSwitcher.js: misspelling（拼写错误）

### DIFF
--- a/src/ColorModeSwitcher.js
+++ b/src/ColorModeSwitcher.js
@@ -49,7 +49,7 @@ function ColorModeSwitcher() {
             <Box
                 sx={{
                     position: 'relative',
-                    dispaly: 'flex',
+                    display: 'flex',
                     justifyContent: 'flex-end',
                 }}
             >


### PR DESCRIPTION
Corrected spelling errors