### PR TITLE
Add motion tokens to globals.css

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -1,5 +1,6 @@
 @import "@primer/primitives/dist/css/base/size/size.css";
 @import "@primer/primitives/dist/css/base/typography/typography.css";
+@import "@primer/primitives/dist/css/base/motion/motion.css";
 @import "@primer/primitives/dist/css/functional/size/border.css";
 @import "@primer/primitives/dist/css/functional/size/breakpoints.css";
 @import "@primer/primitives/dist/css/functional/size/size-coarse.css";


### PR DESCRIPTION
This pull request includes a small addition to the `src/globals.css` file. It imports the motion-related CSS styles from `@primer/primitives` to enhance motion and animation support.